### PR TITLE
Skip gradle dependencies download in Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /app
 COPY build.gradle settings.gradle gradlew ./
 COPY gradle gradle/
 
-# Download dependencies
-RUN gradle dependencies --no-daemon
+# Download dependencies (skipped to avoid CI failures)
+# RUN gradle dependencies --no-daemon
 
 # Copy source code
 COPY src src/


### PR DESCRIPTION
## Purpose
The user is setting up a web service deployment on Render with a PostgreSQL database. They encountered build issues during the Docker deployment process, specifically related to dependency downloads that were causing CI failures.

## Code changes
- Commented out the `RUN gradle dependencies --no-daemon` command in the Dockerfile
- Added explanatory comment indicating this step is skipped to avoid CI failures
- This prevents the Docker build from attempting to download Gradle dependencies during the build process, which was causing deployment issues on Render

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d5c90c5a73fc417fb76c6b32596b7673/glow-sanctuary)

👀 [Preview Link](https://d5c90c5a73fc417fb76c6b32596b7673-glow-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d5c90c5a73fc417fb76c6b32596b7673</projectId>-->
<!--<branchName>glow-sanctuary</branchName>-->